### PR TITLE
将版本更新时下载提示改为“current/total (progress)”

### DIFF
--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -476,7 +476,7 @@
   "user_api_update_alert": "Custom source [{name}] found new version",
   "user_api_update_alert_open_url": "Open update address",
   "version_btn_close": "Close",
-  "version_btn_downloading": "I am trying to download...{total}/{current} ({progress}%)",
+  "version_btn_downloading": "I am trying to download...{current}/{total} ({progress}%)",
   "version_btn_failed": "Retry",
   "version_btn_ignore": "Ignore",
   "version_btn_ignore_cancel": "Cancel ignore",

--- a/src/lang/zh_cn.json
+++ b/src/lang/zh_cn.json
@@ -476,7 +476,7 @@
   "user_api_update_alert": "自定义源 [{name}] 发现新版本",
   "user_api_update_alert_open_url": "打开更新地址",
   "version_btn_close": "关闭",
-  "version_btn_downloading": "正在努力下载中...{total}/{current} ({progress}%)",
+  "version_btn_downloading": "正在努力下载中...{current}/{total} ({progress}%)",
   "version_btn_failed": "重试",
   "version_btn_ignore": "忽略",
   "version_btn_ignore_cancel": "取消忽略",


### PR DESCRIPTION
当前版本下，更新软件的下载进度提示如下：
![Screenshot](https://github.com/lyswhut/lx-music-mobile/assets/83524927/7a493b88-db4a-46fe-82e8-d363a76750f6)

现在，在大多主流浏览器、[`tqdm`](https://tqdm.github.io/) 和电脑版洛雪中中，都使用 `{current}/{total} ({progress%})` 的格式来展示进度。然而，洛雪当前的显示方式恰好与其相反。为提升用户体验，建议进行相应修改。