### PR TITLE
Try add bluetooth lyric but not work

### DIFF
--- a/android/app/src/main/java/cn/toside/music/mobile/lyric/BluetoothLyric.java
+++ b/android/app/src/main/java/cn/toside/music/mobile/lyric/BluetoothLyric.java
@@ -20,7 +20,6 @@ import java.util.List;
 import java.util.Objects;
 
 public class BluetoothLyric extends LyricPlayer {
-  LyricBluetoothSender lyricBluetoothSender = null;
   LyricEvent lyricEvent = null;
   ReactApplicationContext reactAppContext;
 

--- a/android/app/src/main/java/cn/toside/music/mobile/lyric/BluetoothLyric.java
+++ b/android/app/src/main/java/cn/toside/music/mobile/lyric/BluetoothLyric.java
@@ -1,0 +1,90 @@
+package cn.toside.music.mobile.lyric;
+
+import static java.lang.Integer.min;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.Bundle;
+import android.util.Log;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.WritableMap;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Objects;
+
+public class BluetoothLyric extends LyricPlayer {
+  LyricBluetoothSender lyricBluetoothSender = null;
+  LyricEvent lyricEvent = null;
+  ReactApplicationContext reactAppContext;
+
+  boolean isSendBluetoothLyric = true;
+  // String lastText = "LX Music ^-^";
+  List lines = new ArrayList();
+  String lyricText = "";
+  String titleText = "";
+  String singerText = "";
+  String albumText = "";
+
+  BluetoothLyric(ReactApplicationContext reactContext, float playbackRate) {
+    this.reactAppContext = reactContext;
+    this.playbackRate = playbackRate;
+    this.lyricEvent = new LyricEvent(reactContext);
+  }
+
+
+  private void setLyricToSendBluetooth(int lineNum) {
+    if (lineNum >= 0 && lineNum < lines.size()) {
+      HashMap line = (HashMap) lines.get(lineNum);
+      if (line != null) {
+        String fakeSingerLine = titleText + "-" + singerText;
+        String lyricLine = (String) line.get("text");
+        String lyricShow = lyricLine.substring(0, min(lyricLine.length(), 30));
+        String artistShow = fakeSingerLine.substring(0, min(fakeSingerLine.length(), 30));
+        String albumShow = albumText.substring(0, min(albumText.length(), 30));
+        WritableMap params = Arguments.createMap();
+        params.putString("title", lyricShow);
+        params.putString("singer", artistShow);
+        params.putString("album", albumShow);
+        lyricEvent.sendEvent(lyricEvent.SET_BLUETOOTH_LYRIC, params);
+        // Log.d("Lyric", "send react-bt lyric " + line.get("text"));
+      }
+    }
+  }
+
+
+  public void setLyric(String lyric, String title, String singer, String album) {
+    lyricText = lyric;
+    titleText = title;
+    singerText = singer;
+    albumText = album;
+    super.setLyric(lyric, new ArrayList<String>());
+    // Log.d("Lyric", "set bt lyric " + title);
+  }
+
+  @Override
+  public void onSetLyric(List lines) {
+    this.lines = lines;
+  }
+
+  @Override
+  public void onPlay(int lineNum) {
+    // Log.d("Lyric", "bt on play " + lineNum);
+    if(this.isSendBluetoothLyric) setLyricToSendBluetooth(lineNum);
+  }
+
+  public void pauseLyric() {
+    pause();
+  }
+
+  public void toggleSendBluetoothLyric(boolean isSendBluetoothLyric) {
+    this.isSendBluetoothLyric = isSendBluetoothLyric;
+    // Log.d("Lyric", "toggle bt " + isSendBluetoothLyric);
+  }
+}

--- a/android/app/src/main/java/cn/toside/music/mobile/lyric/BluetoothLyricModule.java
+++ b/android/app/src/main/java/cn/toside/music/mobile/lyric/BluetoothLyricModule.java
@@ -1,0 +1,88 @@
+package cn.toside.music.mobile.lyric;
+
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
+import android.util.Log;
+
+import com.facebook.react.bridge.Arguments;
+import com.facebook.react.bridge.Promise;
+import com.facebook.react.bridge.ReactApplicationContext;
+import com.facebook.react.bridge.ReactContextBaseJavaModule;
+import com.facebook.react.bridge.ReactMethod;
+import com.facebook.react.bridge.ReadableMap;
+
+public class BluetoothLyricModule extends ReactContextBaseJavaModule {
+  private final ReactApplicationContext reactContext;
+  BluetoothLyric bluetoothLyric;
+  // final Map<String, Object> constants = new HashMap<>();
+
+  float playbackRate = 1;
+
+  private int listenerCount = 0;
+
+  BluetoothLyricModule(ReactApplicationContext reactContext) {
+    super(reactContext);
+    this.reactContext = reactContext;
+    bluetoothLyric = new BluetoothLyric(reactContext, playbackRate);
+    // Log.d("Lyric", "init bt lyric");
+  }
+
+  @Override
+  public String getName() {
+    return "BluetoothLyricModule";
+  }
+
+  @ReactMethod
+  public void addListener(String eventName) {
+    if (listenerCount == 0) {
+      // Set up any upstream listeners or background tasks as necessary
+    }
+
+    listenerCount += 1;
+  }
+
+  @ReactMethod
+  public void removeListeners(Integer count) {
+    listenerCount -= count;
+    if (listenerCount == 0) {
+      // Remove upstream listeners, stop unnecessary background tasks
+    }
+  }
+
+  @ReactMethod
+  public void setLyric(String lyric, String title, String singer, String album, Promise promise) {
+    if (bluetoothLyric != null) this.bluetoothLyric.setLyric(lyric, title, singer, album);
+    promise.resolve(null);
+  }
+
+  @ReactMethod
+  public void setPlaybackRate(float playbackRate, Promise promise) {
+    this.playbackRate = playbackRate;
+    // Log.d("Lyric", "set bt lyric rate " + playbackRate);
+    if (bluetoothLyric != null) bluetoothLyric.setPlaybackRate(playbackRate);
+    promise.resolve(null);
+  }
+
+  @ReactMethod
+  public void play(int time, Promise promise) {
+    // Log.d("Lyric", "play bt lyric: " + time);
+    if (bluetoothLyric != null) bluetoothLyric.play(time);
+    promise.resolve(null);
+  }
+
+  @ReactMethod
+  public void pause(Promise promise) {
+    // Log.d("Lyric", "play bt pause");
+    if (bluetoothLyric != null) bluetoothLyric.pauseLyric();
+    promise.resolve(null);
+  }
+
+  @ReactMethod
+  public void toggleSendBluetoothLyric(boolean isSendBluetoothLyric, Promise promise) {
+    if (bluetoothLyric != null) bluetoothLyric.toggleSendBluetoothLyric(isSendBluetoothLyric);
+    promise.resolve(null);
+  }
+
+}

--- a/android/app/src/main/java/cn/toside/music/mobile/lyric/LyricEvent.java
+++ b/android/app/src/main/java/cn/toside/music/mobile/lyric/LyricEvent.java
@@ -10,12 +10,13 @@ import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 public class LyricEvent {
   final String SET_VIEW_POSITION = "set-position";
+  final String SET_BLUETOOTH_LYRIC = "set-bluetooth-lyric";
 
   private final ReactApplicationContext reactContext;
   LyricEvent(ReactApplicationContext reactContext) { this.reactContext = reactContext; }
 
   public void sendEvent(String eventName, @Nullable WritableMap params) {
-    Log.d("Lyric", "senEvent: " + eventName);
+    Log.d("Lyric", "sendEvent: " + eventName);
     reactContext
       .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
       .emit(eventName, params);

--- a/android/app/src/main/java/cn/toside/music/mobile/lyric/LyricPackage.java
+++ b/android/app/src/main/java/cn/toside/music/mobile/lyric/LyricPackage.java
@@ -17,6 +17,6 @@ public class LyricPackage implements ReactPackage {
 
   @Override
   public List<NativeModule> createNativeModules(ReactApplicationContext reactContext) {
-    return Arrays.<NativeModule>asList(new LyricModule(reactContext));
+    return Arrays.<NativeModule>asList(new LyricModule(reactContext), new BluetoothLyricModule(reactContext));
   }
 }

--- a/src/config/defaultSetting.ts
+++ b/src/config/defaultSetting.ts
@@ -31,6 +31,7 @@ const defaultSetting: LX.AppSetting = {
   'player.isShowLyricRoma': false,
   'player.isShowNotificationImage': true,
   'player.isS2t': false,
+  'player.isSendBluetoothLyric': false,
 
   // 'playDetail.isZoomActiveLrc': false,
   // 'playDetail.isShowLyricProgressSetting': false,

--- a/src/core/bluetoothLyric.ts
+++ b/src/core/bluetoothLyric.ts
@@ -1,0 +1,23 @@
+import {
+  setLyric,
+  play,
+  pause,
+  setPlaybackRate,
+  toggleSendBluetoothLyric,
+  onSetBluetoothLyric,
+} from '@/utils/nativeModules/lyricBluetooth'
+import settingState from '@/store/setting/state'
+import playerState from '@/store/player/state'
+import { tranditionalize } from '@/utils/simplify-chinese-main'
+import { getPosition } from '@/plugins/player'
+
+export const playBluetoothLyric = async(time: number) => {
+  const setting = settingState.setting
+  await toggleSendBluetoothLyric(setting['player.isSendBluetoothLyric'])
+  await play(time)
+}
+export const pauseBluetoothLyric = pause
+export const setBluetoothLyric = setLyric
+export const setBluetoothLyricPlaybackRate = setPlaybackRate
+export const OnSetBluetoothLyric = onSetBluetoothLyric
+

--- a/src/core/init/player/lyric.ts
+++ b/src/core/init/player/lyric.ts
@@ -26,15 +26,16 @@ export default async(setting: LX.AppSetting) => {
   OnSetBluetoothLyric(async lyric => {
     let isPlaying = await TrackPlayer.getState() == State.Playing
     if (isPlaying) {
-      let etime = 0
-      etime = await TrackPlayer.getPosition()
+      let etime = await TrackPlayer.getPosition()
+      let duration = await TrackPlayer.getDuration()
+      await TrackPlayer.clearNowPlayingMetadata()
       await TrackPlayer.updateNowPlayingMetadata({
         title: lyric.title,
         artist: lyric.singer,
         album: lyric.album,
+        duration: duration,
         elapsedTime: etime
       }, isPlaying)
-      // toast("react lyric: " + etime + lyric.title, "short")
     }
   })
 

--- a/src/core/init/player/lyric.ts
+++ b/src/core/init/player/lyric.ts
@@ -1,6 +1,9 @@
 import { init as initLyricPlayer, toggleTranslation, toggleRoma, play, pause, stop, setLyric, setPlaybackRate } from '@/core/lyric'
 import { updateSetting } from '@/core/common'
 import { onDesktopLyricPositionChange, showDesktopLyric } from '@/core/desktopLyric'
+import { OnSetBluetoothLyric } from '@/core/bluetoothLyric'
+import TrackPlayer, { State } from 'react-native-track-player'
+import { toast } from '@/utils/tools'
 
 export default async(setting: LX.AppSetting) => {
   await initLyricPlayer()
@@ -20,6 +23,20 @@ export default async(setting: LX.AppSetting) => {
     })
   })
 
+  OnSetBluetoothLyric(async lyric => {
+    let isPlaying = await TrackPlayer.getState() == State.Playing
+    if (isPlaying) {
+      let etime = 0
+      etime = await TrackPlayer.getPosition()
+      await TrackPlayer.updateNowPlayingMetadata({
+        title: lyric.title,
+        artist: lyric.singer,
+        album: lyric.album,
+        elapsedTime: etime
+      }, isPlaying)
+      // toast("react lyric: " + etime + lyric.title, "short")
+    }
+  })
 
   global.app_event.on('play', play)
   global.app_event.on('pause', pause)

--- a/src/core/lyric.ts
+++ b/src/core/lyric.ts
@@ -15,6 +15,12 @@ import {
   toggleDesktopLyricTranslation,
   toggleDesktopLyricRoma,
 } from '@/core/desktopLyric'
+import {
+  playBluetoothLyric,
+  pauseBluetoothLyric,
+  setBluetoothLyric,
+  setBluetoothLyricPlaybackRate
+} from '@/core/bluetoothLyric'
 import { getPosition } from '@/plugins/player'
 import playerState from '@/store/player/state'
 // import settingState from '@/store/setting/state'
@@ -31,8 +37,9 @@ export const init = async() => {
  * @param lyric lyric str
  * @param translation lyric translation
  */
-const handleSetLyric = async(lyric: string, translation = '', romalrc = '') => {
+const handleSetLyric = async(lyric: string, translation = '', romalrc = '', title = '', singer = '', album = '') => {
   lrcSetLyric(lyric, translation, romalrc)
+  await setBluetoothLyric(lyric, title, singer, album)
   await setDesktopLyric(lyric, translation, romalrc)
 }
 
@@ -42,6 +49,7 @@ const handleSetLyric = async(lyric: string, translation = '', romalrc = '') => {
  */
 export const handlePlay = (time: number) => {
   lrcPlay(time)
+  void playBluetoothLyric(time)
   void playDesktopLyric(time)
 }
 
@@ -50,6 +58,7 @@ export const handlePlay = (time: number) => {
  */
 export const pause = () => {
   lrcPause()
+  void pauseBluetoothLyric()
   void pauseDesktopLyric()
 }
 
@@ -66,6 +75,7 @@ export const stop = () => {
  */
 export const setPlaybackRate = async(playbackRate: number) => {
   lrcSetPlaybackRate(playbackRate)
+  await setBluetoothLyricPlaybackRate(playbackRate)
   await setDesktopLyricPlaybackRate(playbackRate)
   if (playerState.isPlay) {
     setTimeout(() => {
@@ -96,6 +106,11 @@ export const toggleRoma = async(isShowLyricRoma: boolean) => {
   if (playerState.isPlay) play()
 }
 
+export const toggleSendBluetoothLyric = async(isSendBluetoothLyric: boolean) => {
+  await toggleSendBluetoothLyric(isSendBluetoothLyric)
+  if (playerState.isPlay) play()
+}
+
 export const play = () => {
   void getPosition().then((position) => {
     handlePlay(position * 1000)
@@ -110,7 +125,10 @@ export const setLyric = async() => {
     let rlrc = ''
     if (playerState.musicInfo.tlrc) tlrc = playerState.musicInfo.tlrc
     if (playerState.musicInfo.rlrc) rlrc = playerState.musicInfo.rlrc
-    await handleSetLyric(playerState.musicInfo.lrc, tlrc, rlrc)
+    let name = playerState.musicInfo.name
+    let singer = playerState.musicInfo.singer
+    let album = playerState.musicInfo.album
+    await handleSetLyric(playerState.musicInfo.lrc, tlrc, rlrc, name, singer, album)
   }
 
   if (playerState.isPlay) play()

--- a/src/lang/en_us.json
+++ b/src/lang/en_us.json
@@ -348,6 +348,7 @@
   "setting_play_save_play_time": "Remember playback progress",
   "setting_play_show_notification_image": "Show song picture in notification bar",
   "setting_play_show_roma": "Show lyrics roman (if available)",
+  "setting_play_send_bluetooth_lyric" : "Enable bluetooth lyric",
   "setting_play_show_translation": "Show lyrics translation (if available)",
   "setting_player": "Play",
   "setting_player_save_play_time": "Remember playback progress",

--- a/src/lang/zh_cn.json
+++ b/src/lang/zh_cn.json
@@ -349,6 +349,7 @@
   "setting_play_show_notification_image": "在通知栏显示歌曲图片",
   "setting_play_show_roma": "显示歌词罗马音（如果可用）",
   "setting_play_show_translation": "显示歌词翻译（如果可用）",
+  "setting_play_send_bluetooth_lyric" : "启用车载蓝牙歌词",
   "setting_player": "播放设置",
   "setting_player_save_play_time": "记住播放进度",
   "setting_search": "搜索设置",

--- a/src/screens/Home/Views/Setting/settings/Player/IsSendBluetoothLyric.tsx
+++ b/src/screens/Home/Views/Setting/settings/Player/IsSendBluetoothLyric.tsx
@@ -1,0 +1,32 @@
+import { updateSetting } from '@/core/common'
+import { useI18n } from '@/lang'
+import { createStyle } from '@/utils/tools'
+import { memo } from 'react'
+import { View } from 'react-native'
+import { useSettingValue } from '@/store/setting/hook'
+
+
+import CheckBoxItem from '../../components/CheckBoxItem'
+import { toggleRoma } from '@/core/lyric'
+
+export default memo(() => {
+  const t = useI18n()
+  const isSendBluetoothLyric = useSettingValue('player.isSendBluetoothLyric')
+  const setSendBluetoothLyric = (isSendBluetoothLyric: boolean) => {
+    updateSetting({ 'player.isSendBluetoothLyric': isSendBluetoothLyric })
+    void toggleRoma(isSendBluetoothLyric)
+  }
+
+  return (
+    <View style={styles.content}>
+      <CheckBoxItem check={isSendBluetoothLyric} onChange={setSendBluetoothLyric} label={t('setting_play_send_bluetooth_lyric')} />
+    </View>
+  )
+})
+
+
+const styles = createStyle({
+  content: {
+    marginTop: 5,
+  },
+})

--- a/src/screens/Home/Views/Setting/settings/Player/index.tsx
+++ b/src/screens/Home/Views/Setting/settings/Player/index.tsx
@@ -9,9 +9,11 @@ import IsAutoCleanPlayedList from './IsAutoCleanPlayedList'
 import IsShowNotificationImage from './IsShowNotificationImage'
 import IsShowLyricTranslation from './IsShowLyricTranslation'
 import IsShowLyricRoma from './IsShowLyricRoma'
+import IsSendBluetoothLyric from './IsSendBluetoothLyric'
 import IsS2T from './IsS2T'
 import MaxCache from './MaxCache'
 import { useI18n } from '@/lang'
+
 
 
 export default memo(() => {
@@ -27,6 +29,7 @@ export default memo(() => {
       <IsShowLyricTranslation />
       <IsShowLyricRoma />
       <IsS2T />
+      <IsSendBluetoothLyric />
       <MaxCache />
       <PlayHighQuality />
     </Section>

--- a/src/types/app_setting.d.ts
+++ b/src/types/app_setting.d.ts
@@ -187,6 +187,11 @@ declare global {
       'player.isS2t': boolean
 
       /**
+       * 是否启用车载蓝牙歌词
+       */
+      'player.isSendBluetoothLyric': boolean
+
+      /**
        * 播放详情页-是否缩放当前播放的歌词行
        */
       // 'playDetail.isZoomActiveLrc': boolean

--- a/src/utils/nativeModules/lyricBluetooth.ts
+++ b/src/utils/nativeModules/lyricBluetooth.ts
@@ -1,0 +1,54 @@
+import { NativeModules, NativeEventEmitter } from 'react-native'
+
+const { BluetoothLyricModule } = NativeModules
+
+/**
+ * play lyric
+ * @param {Number} time play time
+ * @returns {Promise} Promise
+ */
+export const play = async(time: number): Promise<void> => {
+  // if (!isShowLyric) return Promise.resolve()
+  return BluetoothLyricModule.play(time)
+}
+
+/**
+ * pause lyric
+ */
+export const pause = async(): Promise<void> => {
+  // if (!isShowLyric) return Promise.resolve()
+  return BluetoothLyricModule.pause()
+}
+
+/**
+ * set lyric
+ * @param lyric lyric str
+ * @param title song title
+ * @param singer song artist
+ * @param album song album
+ */
+export const setLyric = async(lyric: string, title: string, singer: string, album: string): Promise<void> => {
+  // if (!isShowLyric) return Promise.resolve()
+  return BluetoothLyricModule.setLyric(lyric, title || '', singer || '', album || '')
+}
+
+export const setPlaybackRate = async(rate: number): Promise<void> => {
+  // if (!isShowLyric) return Promise.resolve()
+  return BluetoothLyricModule.setPlaybackRate(rate)
+}
+
+export const toggleSendBluetoothLyric = async(enable: boolean): Promise<void> => {
+  return BluetoothLyricModule.toggleSendBluetoothLyric(enable)
+}
+
+export const onSetBluetoothLyric = (handler: (lyric: { title: string, singer: string, album: string }) => void): () => void => {
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+  const eventEmitter = new NativeEventEmitter(BluetoothLyricModule)
+  const eventListener = eventEmitter.addListener('set-bluetooth-lyric', event => {
+    handler(event as { title: string, singer: string, album: string })
+  })
+
+  return () => {
+    eventListener.remove()
+  }
+}


### PR DESCRIPTION
您好，日常使用中非常希望app能有车载蓝牙歌词功能，repo的issue中也有人多次提到。我对于安卓开发和react开发都不熟，根据互联网资料试图添加蓝牙歌词功能。
目前我是借用了桌面歌词里的LyricPlayer核心逻辑，试图对于每一行歌词更新到蓝牙播放器中，方法上：

1. 很多网上资料比如 [这里](https://stackoverflow.com/questions/61689383/android-update-data-on-car-audio) 和 [这里](https://blog.csdn.net/zhanyue1124/article/details/82319789) 都提到使用MediaSession的updateMetadata来实现，先开始直接在Java部分调用
2. 后来发现 react-native-track-player 内部已经包含了对安卓MediaSession的管理，再创建新的MediaSession有可能有问题，就改为调用它的 TrackPlayer.updateNowPlayingMetadata 函数，这个也是目前这个PR里的代码内容

以上两个版本，在Android Studio中，配合 [bumble](https://google.github.io/bumble/platforms/android.html) 在模拟器中调试，都可以正常更新歌词。
<img width="218" alt="image" src="https://github.com/user-attachments/assets/1a4c351c-f878-43b6-b91b-2dc3b2303ce1">
但是在实际的一辆车上测试，都没有效果，实际表现是一首歌刚开始播放时的第一行歌词能更新，后续就一直不更新了。抓取蓝牙HCI包，并与能正常更新歌词的App比较，发现是Host端没有发送一条TrackChanged消息，应该还是安卓相关代码的问题。
![20241028-172128](https://github.com/user-attachments/assets/952fbd88-4e11-44bc-92ae-bd056167e90a)

我后来注意到您使用的是fork并修改过的 react-native-track-player，看来应该也非常了解其中安卓部分的处理。所以想提一下PR，请您帮忙看一下，是否有哪里的实现有问题，有何其他建议。