### PR TITLE
Increase the list menu width

### DIFF
--- a/src/components/common/Menu.tsx
+++ b/src/components/common/Menu.tsx
@@ -10,7 +10,7 @@ import Text from './Text'
 import { scaleSizeH, scaleSizeW } from '@/utils/pixelRatio'
 
 const menuItemHeight = scaleSizeH(40)
-const menuItemWidth = scaleSizeW(100)
+const menuItemWidth = scaleSizeW(125)
 
 export interface Position { w: number, h: number, x: number, y: number, menuWidth?: number, menuHeight?: number }
 export interface MenuSize { width?: number, height?: number }

--- a/src/screens/Home/Views/Mylist/MyList/ListMenu.tsx
+++ b/src/screens/Home/Views/Mylist/MyList/ListMenu.tsx
@@ -15,7 +15,7 @@ export interface SelectInfo {
 }
 const initSelectInfo = {}
 
-const menuItemWidth = scaleSizeW(110)
+const menuItemWidth = scaleSizeW(130)
 
 
 export interface ListMenuProps {


### PR DESCRIPTION
In the English language, text that is too long will be partially invisible in the list menu.

I don't know how to make the width automatically adapt to the text length. Please advise if you have a better method or suggestion.