### PR TITLE
Fix button wrap on "Extras" settings

### DIFF
--- a/src/screens/Home/Views/Setting/settings/Other/MetaCache.tsx
+++ b/src/screens/Home/Views/Setting/settings/Other/MetaCache.tsx
@@ -76,6 +76,8 @@ const styles = StyleSheet.create({
     marginBottom: 5,
   },
   clearBtn: {
+    gap: 5,
     flexDirection: 'row',
+    flexWrap: 'wrap',
   },
 })


### PR DESCRIPTION
Excessively long text (e.g. English) can cause the second button to extend beyond the screen in vertical screen.

Fix this problem via wrap. Add a gap to increase the necessary aesthetics. 