### PR TITLE
feat(ui): 新增底部 BottomTabBar 与修改 PlayerBar 卡片样式

### DIFF
--- a/src/components/player/PlayerBar/index.tsx
+++ b/src/components/player/PlayerBar/index.tsx
@@ -19,7 +19,12 @@ export default memo(({ isHome = false }: { isHome?: boolean }) => {
   const autoHidePlayBar = useSettingValue('common.autoHidePlayBar')
 
   const playerComponent = useMemo(() => (
-    <View style={{ ...styles.container, backgroundColor: theme['c-content-background'] }}>
+    <View style={{
+      ...styles.container,
+      backgroundColor: theme['c-content-background'],
+      borderColor: theme['c-border-background'],
+      shadowColor: theme['c-primary-dark-1000-alpha-300'],
+    }}>
       <Pic isHome={isHome} />
       <View style={styles.center}>
         <Title isHome={isHome} />
@@ -42,21 +47,23 @@ export default memo(({ isHome = false }: { isHome?: boolean }) => {
 
 const styles = createStyle({
   container: {
-    width: '100%',
-    // height: 100,
-    // paddingTop: progressContentPadding,
-    // marginTop: -progressContentPadding,
-    // backgroundColor: 'rgba(0, 0, 0, .1)',
-    // borderTopWidth: BorderWidths.normal2,
-    paddingVertical: 5,
-    paddingLeft: 5,
-    // backgroundColor: AppColors.primary,
-    // backgroundColor: 'red',
-    borderTopLeftRadius: 6,
-    borderTopRightRadius: 6,
+    width: 'auto',
+    marginHorizontal: 6,
+    marginTop: 4,
+    marginBottom: 4,
+    paddingVertical: 6,
+    paddingLeft: 8,
+    borderRadius: 14,
+    borderWidth: 0.5,
     flexDirection: 'row',
     alignItems: 'center',
-    elevation: 10,
+    shadowOffset: {
+      width: 0,
+      height: 4,
+    },
+    shadowOpacity: 0.15,
+    shadowRadius: 8,
+    elevation: 3,
   },
   left: {
     // borderRadius: 3,
@@ -67,7 +74,7 @@ const styles = createStyle({
     flexDirection: 'column',
     flexGrow: 1,
     flexShrink: 1,
-    paddingLeft: 5,
+    paddingLeft: 8,
     height: '100%',
     // justifyContent: 'space-evenly',
     // height: 48,
@@ -78,8 +85,8 @@ const styles = createStyle({
     alignItems: 'center',
     flexGrow: 0,
     flexShrink: 0,
-    paddingLeft: 5,
-    paddingRight: 5,
+    paddingLeft: 6,
+    paddingRight: 8,
   },
   // row: {
   //   flexDirection: 'row',

--- a/src/screens/Home/Horizontal/index.tsx
+++ b/src/screens/Home/Horizontal/index.tsx
@@ -5,6 +5,7 @@ import StatusBar from '@/components/common/StatusBar'
 import Header from './Header'
 import Main from './Main'
 import { createStyle } from '@/utils/tools'
+import BottomTabBar from '../components/BottomTabBar'
 
 const styles = createStyle({
   container: {
@@ -27,6 +28,7 @@ export default () => {
           <Header />
           <Main />
           <PlayerBar isHome />
+          <BottomTabBar />
         </View>
       </View>
     </>

--- a/src/screens/Home/Vertical/index.tsx
+++ b/src/screens/Home/Vertical/index.tsx
@@ -1,11 +1,13 @@
 import Content from './Content'
 import PlayerBar from '@/components/player/PlayerBar'
+import BottomTabBar from '../components/BottomTabBar'
 
 export default () => {
   return (
     <>
       <Content />
       <PlayerBar isHome />
+      <BottomTabBar />
     </>
   )
 }

--- a/src/screens/Home/components/BottomTabBar.tsx
+++ b/src/screens/Home/components/BottomTabBar.tsx
@@ -1,0 +1,94 @@
+import { memo } from 'react'
+import { TouchableOpacity, View } from 'react-native'
+import { NAV_MENUS } from '@/config/constant'
+import { setNavActiveId } from '@/core/common'
+import { useI18n } from '@/lang'
+import { useNavActiveId } from '@/store/common/hook'
+import { useTheme } from '@/store/theme/hook'
+import { Icon } from '@/components/common/Icon'
+import Text from '@/components/common/Text'
+import { createStyle } from '@/utils/tools'
+import { BorderWidths } from '@/theme'
+
+interface TabItemProps {
+  id: typeof NAV_MENUS[number]['id']
+  icon: typeof NAV_MENUS[number]['icon']
+}
+
+const TabItem = ({ id, icon }: TabItemProps) => {
+  const theme = useTheme()
+  const t = useI18n()
+  const activeId = useNavActiveId()
+  const isActive = activeId == id
+
+  /**
+   * 切换底部导航页签。
+   */
+  const handlePress = () => {
+    if (isActive) return
+    setNavActiveId(id)
+  }
+
+  return (
+    <TouchableOpacity
+      style={[
+        styles.item,
+        isActive ? { backgroundColor: theme['c-primary-light-700-alpha-500'] } : null,
+      ]}
+      onPress={handlePress}
+      activeOpacity={0.75}
+    >
+      <Icon
+        name={icon}
+        size={18}
+        color={isActive ? theme['c-primary-font-active'] : theme['c-font-label']}
+      />
+      <Text
+        style={styles.label}
+        size={11}
+        color={isActive ? theme['c-primary-font-active'] : theme['c-font-label']}
+        numberOfLines={1}
+      >
+        {t(id)}
+      </Text>
+    </TouchableOpacity>
+  )
+}
+
+export default memo(() => {
+  const theme = useTheme()
+  return (
+    <View style={[
+      styles.container,
+      {
+        borderTopColor: theme['c-border-background'],
+        backgroundColor: theme['c-content-background'],
+      },
+    ]}>
+      {NAV_MENUS.map(item => <TabItem key={item.id} id={item.id} icon={item.icon} />)}
+    </View>
+  )
+})
+
+const styles = createStyle({
+  container: {
+    borderTopWidth: BorderWidths.normal,
+    flexDirection: 'row',
+    paddingHorizontal: 6,
+    paddingTop: 6,
+    paddingBottom: 6,
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  item: {
+    flex: 1,
+    minHeight: 42,
+    marginHorizontal: 2,
+    borderRadius: 10,
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
+  label: {
+    marginTop: 2,
+  },
+})


### PR DESCRIPTION
保留原有左右滑动切换，新增 bottomBar 操作更直观，适配小屏和大屏。
Closes #215
Closes #269
Closes #624 
Closes #803


小屏幕效果：

<img width="729" height="1278" alt="ScreenShot_2026-05-07_171509_522" src="https://github.com/user-attachments/assets/5f07dfd9-26be-4a0b-8c82-dec272a25219" />

大屏幕效果：

<img width="1929" height="1095" alt="ScreenShot_2026-05-07_171735_445" src="https://github.com/user-attachments/assets/4b227e66-c33c-4bb1-b4c0-e1c63d8d717d" />

