### PR TITLE
修复qq音乐歌单内歌曲数量接口错误导致无法收藏和更新的问题

### DIFF
--- a/src/utils/musicSdk/tx/songList.js
+++ b/src/utils/musicSdk/tx/songList.js
@@ -242,7 +242,7 @@ export default {
       list: this.filterListDetail(result.songlist),
       page: 1,
       limit: this.limit_song,
-      total: result.songnum,
+      total: result.total_song_num,
       source: 'tx',
       info: {
         name: dirinfo.title,


### PR DESCRIPTION
根据u.y.qq.com/cgi-bin/musicu.fcg接口返回json，更新getListDetail2中返回的total字段。